### PR TITLE
Make easier to use as a CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,19 @@ ZIPファイルをPNGファイルに偽装するPython3実装サンプル
 
 * Qiita - [ZIPファイルをPNGファイルに偽装する方法](https://qiita.com/yoshi389111/items/0c0d2e32bef1141ccd02)
 
+## Install
+
+```sh
+pip install git+https://github.com/yoshi389111/zip-as-png-py
+# or
+pipx install git+https://github.com/yoshi389111/zip-as-png-py
+```
+
+## Usage
+
+```sh
+# usage: zipaspng ZIP-FILE PNG-FILE OUT-FILE
+zipaspng input.zip image.png out.png
+```
+
 [WIP]

--- a/setup.py
+++ b/setup.py
@@ -6,4 +6,7 @@ setup(
     description="disguise zip to png",
     packages=find_packages(exclude=("tests", "docs")),
     test_suite="tests",
+    entry_points = {
+        "console_scripts": ["zipaspng=zipaspng.zipaspng:main"],
+    },
 )

--- a/zipaspng/zipaspng.py
+++ b/zipaspng/zipaspng.py
@@ -112,10 +112,12 @@ def disguise_file(zip_file: str, png_file: str, out_file: str):
        # 偽装結果を出力
        out.write(out_buff)
 
- 
-if __name__ == "__main__":
+def main():
     import sys
     argc = len(sys.argv)
     if argc != 4:
         raise RuntimeError("usage: zipaspng ZIP-FILE PNG-FILE OUT-FILE")
     disguise_file(sys.argv[1], sys.argv[2], sys.argv[3])
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I have created `main` function and added `setup.py` to `entry_points` to use `zipaspng` as a CLI.

```sh
pip install git+https://github.com/eggplants/zip-as-png-py
# or
pipx install git+https://github.com/eggplants/zip-as-png-py
```

```shellsession
$ zipaspng
Traceback (most recent call last):
  File "/home/eggplants/.local/bin/zipaspng", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/eggplants/.local/share/pipx/venvs/zipaspng/lib/python3.11/site-packages/zipaspng/zipaspng.py", line 119, in main
    raise RuntimeError("usage: zipaspng ZIP-FILE PNG-FILE OUT-FILE")
RuntimeError: usage: zipaspng ZIP-FILE PNG-FILE OUT-FILE
$ touch input && zip input.zip input
$ convert -background white label:out.zip input.png
$ zipaspng input.zip input.png out.zip.png
$ file out.zip.png
out.zip.png: PNG image data, 39 x 18, 8-bit grayscale, non-interlaced
```

`out.zip.png`: ![out.zip.png](https://github.com/user-attachments/assets/d93ecb09-40ed-49ec-b163-b872bfc5864d)

```shellsession
$ unzip out.zip.png -d out
Archive:  out.zip.png
 extracting: out/input
```